### PR TITLE
fix multiplication bug

### DIFF
--- a/src/main/java/me/crylonz/ChestData.java
+++ b/src/main/java/me/crylonz/ChestData.java
@@ -154,26 +154,34 @@ public final class ChestData implements ConfigurationSerializable {
         final int armorStandShiftY = 1;
 
         if (chestLocation.getWorld() != null) {
-
+            if(chestLocation.getChunk().isLoaded()){
+                doRemoveArmorStands(radius,armorStandShiftY);
+                return true;
+            }
             chestLocation.getChunk().setForceLoaded(true);
 
-            Collection<Entity> entities = chestLocation.getWorld().getNearbyEntities(
-                    new Location(chestLocation.getWorld(), chestLocation.getX(), chestLocation.getY() + armorStandShiftY,
-                            chestLocation.getZ()), radius, radius, radius);
-            boolean isEmpty = entities.size() > 0;
-            for (Entity entity : entities) {
-                if (entity.getUniqueId().equals(holographicOwnerId) || entity.getUniqueId().equals(holographicTimerId)) {
-                    entity.remove();
-                }
-            }
+            Bukkit.getScheduler().runTaskLater(DeadChest.plugin,()->{
+                doRemoveArmorStands(radius,armorStandShiftY);
+            },5);
 
-            if (chestLocation.getChunk().isForceLoaded() && chestLocation.getChunk().isLoaded()) {
-                chestLocation.getChunk().setForceLoaded(false);
-            }
-
-            return isEmpty;
+            return true;
         }
         return false;
+    }
+
+    private void doRemoveArmorStands(int radius, int armorStandShiftY){
+        Collection<Entity> entities = chestLocation.getWorld().getNearbyEntities(
+                new Location(chestLocation.getWorld(), chestLocation.getX(), chestLocation.getY() + armorStandShiftY,
+                        chestLocation.getZ()), radius, radius, radius);
+        for (Entity entity : entities) {
+            if (entity.getUniqueId().equals(holographicOwnerId) || entity.getUniqueId().equals(holographicTimerId)) {
+                entity.remove();
+            }
+        }
+
+        if (chestLocation.getChunk().isForceLoaded() && chestLocation.getChunk().isLoaded()) {
+            chestLocation.getChunk().setForceLoaded(false);
+        }
     }
 
     @Override

--- a/src/main/java/me/crylonz/DeadChestManager.java
+++ b/src/main/java/me/crylonz/DeadChestManager.java
@@ -151,9 +151,8 @@ public class DeadChestManager {
                     }
                 }
             }
-            if (chestData.removeArmorStand()) {
-                chestDataIt.remove();
-            }
+            chestData.removeArmorStand();
+            chestDataIt.remove();
 
             return true;
         }


### PR DESCRIPTION
Fixes an issue when a dead chest expires in an unloaded chunk that causes the items to drop every second.
Should also fix that Armorstands aren't removed when the chunk wasn't loaded.

The expired dead chests wasn't removed from the ChestData ArrayList.