### PR TITLE
Added option to repair command

### DIFF
--- a/src/main/java/me/crylonz/commands/DCCommandExecutor.java
+++ b/src/main/java/me/crylonz/commands/DCCommandExecutor.java
@@ -57,13 +57,15 @@ public class DCCommandExecutor implements CommandExecutor {
                         if (p.hasPermission(Permission.ADMIN.label)) {
                             Collection<Entity> entities = p.getWorld().getNearbyEntities(
                                     p.getLocation(), 100.0D, 25.0D, 100.0D);
-
+                            boolean forceRemove = false;
+                            if (args.length == 2)
+                                forceRemove = args[1].equalsIgnoreCase("force");
                             int holoRemoved = 0;
                             for (Entity entity : entities) {
                                 if (entity.getType() == EntityType.ARMOR_STAND) {
                                     ArmorStand as = (ArmorStand) entity;
 
-                                    if (as.hasMetadata("deadchest")) {
+                                    if (as.hasMetadata("deadchest") || forceRemove) {
                                         holoRemoved++;
                                         entity.remove();
                                     }

--- a/src/main/java/me/crylonz/commands/TabCompletion.java
+++ b/src/main/java/me/crylonz/commands/TabCompletion.java
@@ -52,7 +52,9 @@ public class TabCompletion implements TabCompleter {
                             }
                         }
                     }
-
+                    if (args[0].equals("repair") && player.hasPermission(Permission.ADMIN.label)) {
+                        list.add("force");
+                    }
                     if (args[0].equals("list")) {
                         if (PermissionUtils.hasAdminOr(player, Permission.LIST_OTHER)) {
                             list.add("all");


### PR DESCRIPTION
If you restart the server it will not find the deadchest spawned armorstands. But this option will instead remove all armorstands close to the player (So it could also remove wrong stands).

This will force remove all armorstands no mater if it conected to deadchest or not.

Don´t know if /deadchest:dc repair force or /deadchest:dc repair true is best option.