### PR TITLE
New plugin version 1.16.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+## Deadchest 4.16.1
++ Fixes amount of stored experience recovered from chest after death, same amount restored as dying in vanilla
+
 ## Deadchest 4.11
 
 + Adding auto-updater

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>my.crylonz</groupId>
     <artifactId>DeadChest</artifactId>
-    <version>4.16.0</version>
+    <version>4.16.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/me/crylonz/DeadChestListener.java
+++ b/src/main/java/me/crylonz/DeadChestListener.java
@@ -208,10 +208,14 @@ public class DeadChestListener implements Listener {
                         }
                     }
 
+                    // getDroppedExp() has to be called before setDroppedExp()
+                    // otherwise getDroppedExp() == setDroppedExp()
+                    int newExp;
+                    newExp = computeXpToStore(e);
+
                     if (config.getBoolean(ConfigKey.STORE_XP)) {
                         e.setDroppedExp(0);
                     }
-
 
                     chestData.add(
                             new ChestData(
@@ -221,7 +225,7 @@ public class DeadChestListener implements Listener {
                                     p.hasPermission(Permission.INFINITY_CHEST.label),
                                     holoTime,
                                     holoName,
-                                    computeXpToStore(p)
+                                    newExp
                             )
                     );
 

--- a/src/main/java/me/crylonz/Utils.java
+++ b/src/main/java/me/crylonz/Utils.java
@@ -11,6 +11,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Skull;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -175,10 +176,12 @@ public class Utils {
         }
     }
 
-    public static int computeXpToStore(Player player) {
-
+    public static int computeXpToStore(PlayerDeathEvent entity) {
         if (config.getBoolean(ConfigKey.STORE_XP)) {
-            return player.getTotalExperience();
+            // This does give the player 7 1/2 levels on first death above level 8
+            // if player dies again with 7 1/2 levels, player drops to 4 levels and so on.
+            // this is normal minecraft behaviour
+            return entity.getDroppedExp();
         }
         return 0;
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: DeadChest
 main: me.crylonz.DeadChest
 softdepend: [Multiverse-Core, WorldGuard]
 author: Crylonz
-version: "4.16.0"
+version: "4.16.1"
 description: Keep your inventory in a chest when you die
 api-version: "1.13"
 permissions:


### PR DESCRIPTION
fixes amount of experience restored when collecting death chest. Amount is like dying in vanilla and collecting experience orbs.