### PR TITLE
Allow the storage of a percentage of XP

### DIFF
--- a/deadchest-core/src/main/java/me/crylonz/DeadChest.java
+++ b/deadchest-core/src/main/java/me/crylonz/DeadChest.java
@@ -142,6 +142,7 @@ public class DeadChest extends JavaPlugin {
         config.register(ConfigKey.EXCLUDED_WORLDS.toString(), Collections.emptyList());
         config.register(ConfigKey.EXCLUDED_ITEMS.toString(), Collections.emptyList());
         config.register(ConfigKey.STORE_XP.toString(), false);
+        config.register(ConfigKey.STORE_XP_PERCENTAGE.toString(), 100);
         config.register(ConfigKey.KEEP_INVENTORY_ON_PVP_DEATH.toString(), false);
     }
 

--- a/deadchest-core/src/main/java/me/crylonz/utils/ConfigKey.java
+++ b/deadchest-core/src/main/java/me/crylonz/utils/ConfigKey.java
@@ -24,6 +24,7 @@ public enum ConfigKey {
     EXCLUDED_WORLDS("ExcludedWorld"),
     EXCLUDED_ITEMS("ExcludedItems"),
     STORE_XP("StoreXP"),
+    STORE_XP_PERCENTAGE("StoreXPPercentage"),
     KEEP_INVENTORY_ON_PVP_DEATH("KeepInventoryOnPvpDeath"),
     ITEM_DURABILITY_LOSS_ON_DEATH("item-durability-loss-on-death");
     private final String text;

--- a/deadchest-core/src/main/java/me/crylonz/utils/ExpUtils.java
+++ b/deadchest-core/src/main/java/me/crylonz/utils/ExpUtils.java
@@ -99,7 +99,7 @@ public final class ExpUtils {
 
     public static int getTotalExperienceToStore(Player player) {
         if (config.getBoolean(ConfigKey.STORE_XP)) {
-            return getTotalExperience(player);
+            return getTotalExperience(player) * config.getInt(ConfigKey.STORE_XP_PERCENTAGE) / 100;
         }
         return 0;
     }

--- a/deadchest-core/src/main/resources/config.yml
+++ b/deadchest-core/src/main/resources/config.yml
@@ -72,6 +72,12 @@ DropBlock: 1
 # Store Player XP on Deadchest
 StoreXP: false
 
+# % of XP stored on the deadchest. Only works if StoreXP is true
+# If 0 is used the all the XP from the player vanishes, no XP orb gets dropped on death and no XP gets stored
+# If a value of 100 is used then all the XP is stored on the chest
+# Values higher than 100 are allowed but not recommended as they would duplicate XP
+StoreXPPercentage: 100
+
 # Should we drop DeadChest contents when the timer expires?
 #   > false - DeadChest contents are removed when the timer expires.
 #   > true  - DeadChest contents are dropped when the timer expires.


### PR DESCRIPTION
This allows the plugin to use a % of the player XP to store on the chest, it defaults to 100% and can be changed to any number, including above 100 but that will duplicate XP so not recommended, 