### PR TITLE
Add a check for the world of the clicked block on onClick

### DIFF
--- a/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChestListener.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChestListener.java
@@ -284,7 +284,7 @@ public class DeadChestListener implements Listener {
     public void onClick(PlayerInteractEvent e) {
         if (e.getAction().equals(Action.RIGHT_CLICK_BLOCK)) {
             for (ChestData cd : chestData) {
-                if (cd.getChestLocation().getWorld() == e.getPlayer().getWorld() &&
+                if (cd.getChestLocation().getWorld() == e.getPlayer().getWorld() && e.getPlayer().getWorld() == e.getClickedBlock().getWorld() &&
                         cd.getChestLocation().distance(e.getClickedBlock().getLocation()) <= 1) {
                     e.setCancelled(true);
                     break;


### PR DESCRIPTION
This fixes a compatiblity bug with the plugin multiverse-signportals, what was happening was that when right clicking a sign the player would get teleported to the world and then the onClick would run, and because the player is in the correct world as the deadchest, the check would return and it would later fail to find the distance of the block and the player because they are in completely different worlds, stacktrace of the bug sent, this fixes exactly that
```
[12:13:25 ERROR]: Could not pass event PlayerInteractEvent to DeadChest v4.19.0
java.lang.IllegalArgumentException: Cannot measure distance between world and flatroom
	at org.bukkit.Location.distanceSquared(Location.java:510) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.Location.distance(Location.java:493) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
	at me.crylonz.deadchest.DeadChestListener.onClick(DeadChestListener.java:288) ~[dead-chest-4.19.0.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor204.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:77) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:git-Paper-318]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.20.2.jar:git-Paper-318]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:126) ~[paper-1.20.2.jar:git-Paper-318]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:615) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_20_R2.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:595) ~[paper-1.20.2.jar:git-Paper-318]
	at net.minecraft.server.level.ServerPlayerGameMode.useItemOn(ServerPlayerGameMode.java:536) ~[?:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handleUseItemOn(ServerGamePacketListenerImpl.java:1908) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.handle(ServerboundUseItemOnPacket.java:37) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.a(ServerboundUseItemOnPacket.java:9) ~[?:?]
	at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:53) ~[?:?]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.20.2.jar:git-Paper-318]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1324) ~[paper-1.20.2.jar:git-Paper-318]
	at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:193) ~[paper-1.20.2.jar:git-Paper-318]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1301) ~[paper-1.20.2.jar:git-Paper-318]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1294) ~[paper-1.20.2.jar:git-Paper-318]
	at net.minecraft.util.thread.BlockableEventLoop.runAllTasks(BlockableEventLoop.java:114) ~[?:?]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1410) ~[paper-1.20.2.jar:git-Paper-318]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1156) ~[paper-1.20.2.jar:git-Paper-318]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:315) ~[paper-1.20.2.jar:git-Paper-318]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```