### PR TITLE
Fix auto-equip feature for Minecraft 1.21.8 and add inventory position restoration

### DIFF
--- a/deadchest-core/src/main/resources/plugin.yml
+++ b/deadchest-core/src/main/resources/plugin.yml
@@ -1,8 +1,8 @@
 name: DeadChest
 main: me.crylonz.deadchest.DeadChest
-softdepend: [Multiverse-Core, WorldGuard]
+softdepend: [Multiverse-Core, WorldGuard, MinePacks]
 author: Crylonz
-version: 4.21.1
+version: 4.21.2
 description: Keep your inventory in a chest when you die
 api-version: "1.13"
 permissions:


### PR DESCRIPTION
This PR improves the `DeadChest` plugin with better inventory handling, `MinePacks` compatibility, and more accurate item restoration.

### Key Changes:

- **Inventory Handling:**  
  Replaced stream-based item filtering with an indexed loop in `DeadChestListener.java` to preserve inventory layout and `null` slots.

- **MinePacks Compatibility:**  
  Prevented backpack duplication by detecting and removing `MinePacks` backpacks from drops. Declared `MinePacks` as a soft dependency in `plugin.yml`.

- **Item Restoration:**  
  Enhanced restoration logic to auto-equip armor, shields, and restore items to their original inventory slots using a two-pass approach.

- **Metadata Update:**  
  Bumped plugin version from `4.21.1` to `4.21.2`.