### PR TITLE
Better blacklist system and improved inventory restoration 

### DIFF
--- a/deadchest-core/build.gradle.kts
+++ b/deadchest-core/build.gradle.kts
@@ -8,15 +8,26 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
 }
 
-tasks {
-    compileTestJava {
-        sourceCompatibility = JavaVersion.VERSION_17.toString()
-        targetCompatibility = JavaVersion.VERSION_17.toString()
-    }
+// Keep compatibility for user with old java version
+tasks.named<JavaCompile>("compileJava") {
+    options.release.set(8)
+}
+
+tasks.named<JavaCompile>("compileTestJava") {
+    options.release.set(17)
+}
+
+
+tasks.test {
+    useJUnitPlatform()
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    })
 }
 
 val pluginDir: String by lazy {
@@ -49,11 +60,7 @@ dependencies {
     testImplementation("com.github.seeseemelk:MockBukkit-v1.20:3.70.0")
 }
 
-configurations.all {
-    resolutionStrategy {
-        force("io.papermc.paper:paper-api:1.20.4-R0.1-20240205.114523-90")
-    }
-}
+
 
 tasks.named<Test>("test") {
     useJUnitPlatform()

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChest.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChest.java
@@ -60,7 +60,7 @@ public class DeadChest extends JavaPlugin {
         this.db = new SQLite(this);
         db.init();
 
-        Bukkit.createInventory(new IgnoreInventoryHolder(), 36, "Ignore list");
+        ignoreList = Bukkit.createInventory(new IgnoreInventoryHolder(), 36, "Ignore list");
         config = new DeadChestConfig(this);
         plugin = this;
         fileManager = new FileManager(this);

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChest.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChest.java
@@ -6,9 +6,11 @@ import me.crylonz.deadchest.utils.ConfigKey;
 import me.crylonz.deadchest.utils.DeadChestConfig;
 import me.crylonz.deadchest.utils.DeadChestUpdater;
 import org.bstats.bukkit.Metrics;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginManager;
@@ -21,6 +23,7 @@ import java.util.logging.Logger;
 
 import static me.crylonz.deadchest.DeadChestManager.*;
 import static me.crylonz.deadchest.Utils.generateLog;
+import static me.crylonz.deadchest.utils.IgnoreItemListRepository.loadIgnoreIntoInventory;
 
 public class DeadChest extends JavaPlugin {
 
@@ -32,10 +35,14 @@ public class DeadChest extends JavaPlugin {
     public static Localization local;
     public static Plugin plugin;
 
+    public static Inventory ignoreList;
+
     public static boolean bstats = true;
     public static boolean isChangesNeedToBeSave = false;
 
     public static DeadChestConfig config;
+
+    public static SQLite db;
 
     static {
         ConfigurationSerialization.registerClass(ChestData.class, "ChestData");
@@ -50,7 +57,10 @@ public class DeadChest extends JavaPlugin {
     }
 
     public void onEnable() {
+        this.db = new SQLite(this);
+        db.init();
 
+        Bukkit.createInventory(new IgnoreInventoryHolder(), 36, "Ignore list");
         config = new DeadChestConfig(this);
         plugin = this;
         fileManager = new FileManager(this);
@@ -72,7 +82,7 @@ public class DeadChest extends JavaPlugin {
         PluginManager pm = getServer().getPluginManager();
         pm.registerEvents(new DeadChestListener(this), this);
 
-        // Wich block can be used as grave ?
+        // Which block can be used as grave ?
         graveBlocks.add(Material.CHEST);
         graveBlocks.add(Material.PLAYER_HEAD);
         graveBlocks.add(Material.ENDER_CHEST);
@@ -168,6 +178,9 @@ public class DeadChest extends JavaPlugin {
                 chestData = tmp;
             }
         }
+
+        // ignore list
+        loadIgnoreIntoInventory(ignoreList);
 
         // locale file for translation
         if (!fileManager.getLocalizationConfigFile().exists()) {

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChestListener.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChestListener.java
@@ -53,7 +53,7 @@ public class DeadChestListener implements Listener {
         return plugin.config;
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.LOW)
     public void onPlayerDeathEvent(PlayerDeathEvent e) {
 
         if (e.getKeepInventory()) {

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/IgnoreInventoryHolder.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/IgnoreInventoryHolder.java
@@ -1,0 +1,11 @@
+package me.crylonz.deadchest;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public class IgnoreInventoryHolder implements InventoryHolder {
+    @Override
+    public Inventory getInventory() {
+        throw new UnsupportedOperationException("Inventory is managed externally.");
+    }
+}

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/SQLite.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/SQLite.java
@@ -1,0 +1,67 @@
+package me.crylonz.deadchest;
+
+import org.bukkit.plugin.Plugin;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class SQLite {
+    private final Plugin plugin;
+    private Connection conn;
+
+    public SQLite(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public synchronized void init() {
+        try {
+            if (!plugin.getDataFolder().exists()) {
+                plugin.getDataFolder().mkdirs();
+            }
+            Path dbPath = plugin.getDataFolder().toPath().resolve("data.db");
+            String url = "jdbc:sqlite:" + dbPath.toString().replace("\\", "/");
+
+            conn = DriverManager.getConnection(url);
+
+            try (Statement st = conn.createStatement()) {
+                st.execute("PRAGMA journal_mode=WAL");
+                st.execute("PRAGMA synchronous=NORMAL");
+                st.execute("PRAGMA foreign_keys=ON");
+            }
+
+            createSchema();
+        } catch (SQLException e) {
+            throw new RuntimeException("SQLite init failed", e);
+        }
+    }
+
+    private void createSchema() throws SQLException {
+        try (Statement st = conn.createStatement()) {
+            st.execute(
+                    "CREATE TABLE IF NOT EXISTS ignore_items ("
+                            + "slot INTEGER PRIMARY KEY, "
+                            + "data BLOB NOT NULL"
+                            + ")"
+            );
+        }
+    }
+
+    public synchronized Connection connection() throws SQLException {
+        if (conn == null || conn.isClosed()) {
+            init();
+        }
+        return conn;
+    }
+
+    public synchronized void close() {
+        try {
+            if (conn != null && !conn.isClosed()) {
+                conn.close();
+            }
+        } catch (SQLException ignored) {
+        }
+    }
+}

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/commands/DCCommandExecutor.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/commands/DCCommandExecutor.java
@@ -34,6 +34,7 @@ public class DCCommandExecutor implements CommandExecutor {
         commandRegistration.registerListOwn();          // dc list
         commandRegistration.registerListOther();        // dc list all | <PlayerName>
         commandRegistration.registerGiveBack();         // dc giveback <PlayerName>
+        commandRegistration.registerIgnoreList();       // dc ignore
 
         if (!commandRegistration.isCommandSucceed()) {
             sender.sendMessage(local.get("loc_prefix") + ChatColor.RED + "Unrecognized Command");

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/commands/DCCommandRegistrationService.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/commands/DCCommandRegistrationService.java
@@ -18,6 +18,7 @@ import java.util.*;
 
 import static me.crylonz.deadchest.DeadChest.*;
 import static me.crylonz.deadchest.DeadChestManager.cleanAllDeadChests;
+import static me.crylonz.deadchest.utils.IgnoreItemListRepository.loadIgnoreIntoInventory;
 
 public class DCCommandRegistrationService extends DCCommandRegistration {
 
@@ -29,6 +30,7 @@ public class DCCommandRegistrationService extends DCCommandRegistration {
         registerCommand("dc reload", Permission.ADMIN.label, () -> {
             fileManager.reloadChestDataConfig();
             fileManager.reloadLocalizationConfig();
+            loadIgnoreIntoInventory(ignoreList);
             plugin.reloadConfig();
             plugin.registerConfig();
 
@@ -280,6 +282,12 @@ public class DCCommandRegistrationService extends DCCommandRegistration {
             } else {
                 sender.sendMessage(local.get("loc_prefix") + local.get("loc_givebackInfo"));
             }
+        });
+    }
+
+    public void registerIgnoreList() {
+        registerCommand("dc ignore ", Permission.ADMIN.label, () -> {
+            player.openInventory(ignoreList);
         });
     }
 }

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/commands/DCTabCompletion.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/commands/DCTabCompletion.java
@@ -29,6 +29,7 @@ public class DCTabCompletion implements TabCompleter {
                         list.add("removeinfinite");
                         list.add("removeall");
                         list.add("repair");
+                        list.add("ignore");
                     }
 
                     if (PermissionUtils.hasAdminOrOneOf(player, PermissionUtils.LIST_ALL)) {

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/utils/IgnoreItemListRepository.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/utils/IgnoreItemListRepository.java
@@ -1,0 +1,71 @@
+package me.crylonz.deadchest.utils;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.sql.*;
+
+import static me.crylonz.deadchest.DeadChest.db;
+import static me.crylonz.deadchest.DeadChest.log;
+
+
+public class IgnoreItemListRepository {
+
+    public static void loadIgnoreIntoInventory(Inventory inv) {
+        try {
+            boolean any = false;
+            ItemStack[] contents = new ItemStack[inv.getSize()];
+
+            try (Connection connection = db.connection();
+                 PreparedStatement request = connection.prepareStatement("SELECT slot, data FROM ignore_items");
+                 ResultSet result = request.executeQuery()) {
+
+                while (result.next()) {
+                    int slot = result.getInt("slot");
+                    if (slot < 0 || slot >= contents.length) continue;
+                    byte[] data = result.getBytes("data");
+                    contents[slot] = ItemBytes.fromBytes(data);
+                    any = true;
+                }
+            }
+
+            if (any) {
+                inv.setContents(contents);
+                log.info("[DeadChest] Ignore list loaded from SQLite.");
+                return;
+            }
+
+            log.info("[DeadChest] Ignore list empty (no SQLite row)");
+
+        } catch (SQLException e) {
+            log.severe("[DeadChest] Failed to load ignore list from SQLite: " + e.getMessage());
+        }
+    }
+
+    public static void saveIgnoreIntoInventory(Inventory inv) {
+
+        try {
+            try (Connection c = db.connection();
+                 Statement clear = c.createStatement()) {
+                clear.executeUpdate("DELETE FROM ignore_items");
+            }
+            String sql = "INSERT INTO ignore_items(slot, data) VALUES(?, ?)";
+            try (Connection connection = db.connection();
+                 PreparedStatement request = connection.prepareStatement(sql)) {
+
+                ItemStack[] contents = inv.getContents();
+                for (int slot = 0; slot < contents.length; slot++) {
+                    byte[] bytes = ItemBytes.toBytes(contents[slot]);
+                    if (bytes == null || bytes.length == 0) continue;
+                    request.setInt(1, slot);
+                    request.setBytes(2, bytes);
+                    request.addBatch();
+                }
+                request.executeBatch();
+            }
+            log.info("[DeadChest] Ignore list saved to SQLite.");
+        } catch (SQLException e) {
+            log.severe("[DeadChest] Failed to save ignore list to SQLite: " + e.getMessage());
+        }
+    }
+}

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/utils/ItemBytes.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/utils/ItemBytes.java
@@ -1,0 +1,98 @@
+package me.crylonz.deadchest.utils;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+public final class ItemBytes {
+    private ItemBytes() {
+    }
+
+    /**
+     * We used customs paper methods if available via reflexion to keep java 8 compatibility
+     */
+    private static volatile Method SERIALIZE_AS_BYTES;   // instance method: byte[] serializeAsBytes()
+    private static volatile Method DESERIALIZE_BYTES;    // static method: ItemStack deserializeBytes(byte[])
+
+    public static byte[] toBytes(ItemStack item) {
+        if (item == null || item.getType().isAir()) return new byte[0];
+
+        // paper (via réflexion)
+        Method m = getSerializeAsBytes();
+        if (m != null) {
+            try {
+                Object res = m.invoke(item);
+                if (res instanceof byte[]) return (byte[]) res;
+            } catch (ReflectiveOperationException e) {
+                // spigot fallback
+            }
+        }
+
+        // Spigot fallback
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             BukkitObjectOutputStream oos = new BukkitObjectOutputStream(baos)) {
+            oos.writeObject(item);
+            return baos.toByteArray();
+        } catch (IOException ex) {
+            throw new RuntimeException("Failed to serialize ItemStack (Spigot fallback)", ex);
+        }
+    }
+
+    public static ItemStack fromBytes(byte[] bytes) {
+        if (bytes == null || bytes.length == 0) return null;
+
+        //  Paper (via réflexion)
+        Method m = getDeserializeBytes();
+        if (m != null) {
+            try {
+                Object res = m.invoke(null, bytes);
+                if (res instanceof ItemStack) return (ItemStack) res;
+            } catch (ReflectiveOperationException e) {
+                // Spigot fallback
+            }
+        }
+
+        // Spigot fallback
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+             BukkitObjectInputStream ois = new BukkitObjectInputStream(bais)) {
+            return (ItemStack) ois.readObject();
+        } catch (IOException | ClassNotFoundException ex) {
+            throw new RuntimeException("Failed to deserialize ItemStack (Spigot fallback)", ex);
+        }
+    }
+
+    // --- Helpers réflexion (thread-safe, Java 8) ---
+
+    private static Method getSerializeAsBytes() {
+        Method cached = SERIALIZE_AS_BYTES;
+        if (cached != null) return cached;
+        try {
+            Method m = ItemStack.class.getMethod("serializeAsBytes");
+            m.setAccessible(true);
+            SERIALIZE_AS_BYTES = m;
+            return m;
+        } catch (NoSuchMethodException ignored) {
+            SERIALIZE_AS_BYTES = null;
+            return null;
+        }
+    }
+
+    private static Method getDeserializeBytes() {
+        Method cached = DESERIALIZE_BYTES;
+        if (cached != null) return cached;
+        try {
+            Method m = ItemStack.class.getMethod("deserializeBytes", byte[].class);
+            m.setAccessible(true);
+            DESERIALIZE_BYTES = m;
+            return m;
+        } catch (NoSuchMethodException ignored) {
+            DESERIALIZE_BYTES = null;
+            return null;
+        }
+    }
+}

--- a/deadchest-core/src/main/resources/plugin.yml
+++ b/deadchest-core/src/main/resources/plugin.yml
@@ -1,8 +1,8 @@
 name: DeadChest
 main: me.crylonz.deadchest.DeadChest
-softdepend: [Multiverse-Core, WorldGuard, MinePacks]
+softdepend: [ Multiverse-Core, WorldGuard ]
 author: Crylonz
-version: 4.21.2
+version: 4.22.0
 description: Keep your inventory in a chest when you die
 api-version: "1.13"
 permissions:


### PR DESCRIPTION
## Summary

This PR aggregates recent improvements contributed by multiple developers based on inventory, item storage filtering and ordering

### Changes

- **Event priority adjustment** — Changed `PlayerDeathEvent` listener priority from **LOWEST** to **LOW** to allow other plugins more control over death events.  
  _Contributed by_ @broken1arrow

- **Optimized chest data storage** — Prevents storing `null` values in `chestData`.  
  _Contributed by_ @broken1arrow

- **Improved inventory restoration**  
  - Keeps items in their original slots.  
  - Enhanced armor restoration logic.  
  _Contributed by_ @shakil-muntasir, @gnago

- **New admin command** — `/dc ignore`  
  - Opens an inventory where admins can place items that will be ignored by Deadchest (including custom items).  
  - Items are stored in a **binary format** in a SQLite database.  
  - On **Paper** servers, Paper’s serialization (DFU-preserving) is used.  
  - On other servers, the classic Spigot binary serialization is used.

- **Custom mechanic for ignore list** — Some plugins (e.g., Minepack) prevent moving objects from inventories.  
  - A custom mechanic now allows adding any item to the ignored list.  
  - Items are filtered to prevent duplicates and stacking.
  - left click to the bottom inventory to add item to the list. Left click to the ignore list to remove the item from it

**Ignore inventory list**

<img width="664" height="628" alt="image" src="https://github.com/user-attachments/assets/799345ff-b299-4069-a44c-1905e6291451" />

**Test**

- Test on Paper 1.21.8 / 1.21.6
- Spigot 1.21.8
- with Minepack